### PR TITLE
Only check revision user if set

### DIFF
--- a/block_access.module
+++ b/block_access.module
@@ -23,7 +23,7 @@ function block_access_entity_access(EntityInterface $entity, $operation, Account
   return AccessResult::allowedIfHasPermission($account, $any)
     ->orIf(
       AccessResult::allowedIfHasPermission($account, $own)
-      ->andIf(AccessResult::allowedIf($entity instanceof RevisionLogInterface && $entity->getRevisionUser()->id() === $account->id()))
+      ->andIf(AccessResult::allowedIf($entity instanceof RevisionLogInterface && $entity->getRevisionUser() && $entity->getRevisionUser()->id() === $account->id()))
       ->addCacheableDependency($entity)
     );
 }


### PR DESCRIPTION
Error check that a revision user has been set prior to the comparison as the 8.2 drupal upgrade breaks without it.
